### PR TITLE
PiefedShrieker を ginseng-piefed gem 継承に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '>= 3.4', '< 5.0'
 gem 'feedjira', '~>3.0'
 gem 'ginseng-core', github: 'pooza/ginseng-core', branch: 'main', require: 'ginseng'
 gem 'ginseng-fediverse', github: 'pooza/ginseng-fediverse', branch: 'main', require: 'ginseng/fediverse'
+gem 'ginseng-piefed', github: 'pooza/ginseng-piefed', branch: 'main', require: 'ginseng/piefed'
 gem 'ginseng-youtube', github: 'pooza/ginseng-youtube', branch: 'main', require: 'ginseng/you_tube'
 gem 'icalendar'
 gem 'icalendar-rrule', github: 'pooza/icalendar-rrule',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,13 @@ GIT
     ginseng-fediverse (1.8.21)
 
 GIT
+  remote: https://github.com/pooza/ginseng-piefed.git
+  revision: 125e86e3a426c68b0d1cf4d35b8f9d705d93bb0a
+  branch: main
+  specs:
+    ginseng-piefed (0.1.0)
+
+GIT
   remote: https://github.com/pooza/ginseng-youtube.git
   revision: 453a25139a2de765c6f9ad03d450f5053bddfcba
   branch: main
@@ -285,6 +292,7 @@ DEPENDENCIES
   feedjira (~> 3.0)
   ginseng-core!
   ginseng-fediverse!
+  ginseng-piefed!
   ginseng-youtube!
   icalendar
   icalendar-rrule!
@@ -332,6 +340,7 @@ CHECKSUMS
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   ginseng-core (1.15.21)
   ginseng-fediverse (1.8.21)
+  ginseng-piefed (0.1.0)
   ginseng-youtube (2.0.1)
   httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5

--- a/app/lib/tomato_shrieker/shrieker/piefed_shrieker.rb
+++ b/app/lib/tomato_shrieker/shrieker/piefed_shrieker.rb
@@ -1,29 +1,15 @@
 module TomatoShrieker
-  class PiefedShrieker
-    include Package
-
-    attr_reader :http
-
+  class PiefedShrieker < Ginseng::Piefed::Service
     def initialize(params = {})
-      @params = params.deep_symbolize_keys
-      @http = HTTP.new
-      @http.base_uri = uri
+      params = params.deep_symbolize_keys
+      params[:url] = "https://#{params[:host]}" if params[:host] && !params[:url]
+      params[:user] = params[:user_id] if params[:user_id] && !params[:user]
+      super
       login
     end
 
-    def uri
-      @uri ||= Ginseng::URI.parse("https://#{@params[:host]}")
-      return @uri if @uri&.absolute?
-    end
-
-    def login
-      response = http.post("/api/#{api_version}/user/login", {
-        body: {
-          username: @params[:user_id],
-          password: (@params[:password].decrypt rescue @params[:password]),
-        },
-      })
-      @jwt = response['jwt']
+    def api_version
+      return @params[:api_version] || super
     end
 
     def exec(body)
@@ -43,9 +29,7 @@ module TomatoShrieker
       })
     end
 
-    def api_version
-      return @params[:api_version] || 'alpha'
-    end
+    private
 
     def search_template(body)
       unless entry = body[:template].entry


### PR DESCRIPTION
## Summary

- ginseng-piefed gem を Gemfile に追加
- `PiefedShrieker` を `Ginseng::Piefed::Service` の継承に変更
- HTTP クライアント、URI 構築、認証（login/JWT 管理）を gem に委譲
- パラメータ名の差異（`:host`→`:url`, `:user_id`→`:user`）は `initialize` 内で変換

## 背景

mulukhiya-toot-proxy #4146 で PieFed 対応を ginseng-piefed gem に切り出した。
mulukhiya 側の `PiefedClipper` は削除済みで `Ginseng::Piefed::Service` を直接利用。
tomato-shrieker 側は固有ロジック（テンプレート処理）があるため継承で対応。

## Test plan

- [ ] PieFed 投稿ソースが設定されたテスト環境で `exec` が正常動作すること
- [ ] `login` / JWT 管理が gem 側のロジックで動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)