### PR TITLE
fix: RRULE を持たないカレンダーで IcalendarSource がエラーになる (#1421)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    icalendar (2.12.1)
+    icalendar (2.12.2)
       base64
       ice_cube (~> 0.16)
       logger
@@ -350,7 +350,7 @@ CHECKSUMS
   http-cookie (1.1.0) sha256=38a5e60d1527eebc396831b8c4b9455440509881219273a6c99943d29eadbb19
   httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  icalendar (2.12.1) sha256=ecff56c550aed551f29ad1faad0da54bf62362dfaf22a428bd7ad782938fe764
+  icalendar (2.12.2) sha256=b63dfb784b4d1214bceaec40097e61eaf78c8691929d7f217779956d9019d9f5
   icalendar-rrule (0.1.7)
   ice_cube (0.17.0) sha256=32deb45dda4b4acc53505c2f581f6d32b5afc04d29b9004769944a0df5a5fcbe
   json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf

--- a/app/lib/tomato_shrieker/source/icalendar_source.rb
+++ b/app/lib/tomato_shrieker/source/icalendar_source.rb
@@ -105,7 +105,7 @@ module TomatoShrieker
     end
 
     def create_entry(event)
-      event = scan_rrule(event) if event.rrule
+      event = scan_rrule(event) if event.rrule.present?
       event.dtend ||= event.dtstart
       start_date = Time.parse(event.dtstart.to_s).getlocal
       end_date = Time.parse(event.dtend.to_s).getlocal


### PR DESCRIPTION
## Summary

- RRULE を持たないイベントで `scan_rrule` が誤って呼ばれる問題を修正
- icalendar gem を 2.12.2 にセキュリティ更新（ICS injection 対策）

Closes #1421（3.x バックポート）

## Test plan

- [ ] `bundle exec rake test` が通ること
- [ ] RRULE なしのカレンダー（例: `https://cure-api.precure.ml/girls/calendar`）で entries が取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)