### PR TITLE
fix: keep_years による古い記事の投稿フィルタを実装 (#1427)

### DIFF
--- a/app/lib/tomato_shrieker/model/entry.rb
+++ b/app/lib/tomato_shrieker/model/entry.rb
@@ -80,6 +80,7 @@ module TomatoShrieker
       entry = Entry[Entry.insert(parser.parse)]
       return nil unless feed&.touched?
       return nil if entry.published < feed.time
+      return nil if feed.keep_years && entry.published < feed.keep_years.years.ago
       return entry
     rescue SQLite3::BusyException
       sleep(rand(0.5..2.0))

--- a/app/lib/tomato_shrieker/source/feed_source.rb
+++ b/app/lib/tomato_shrieker/source/feed_source.rb
@@ -19,7 +19,7 @@ module TomatoShrieker
     end
 
     def keep_years
-      return self['/keep/years']
+      return self['/keep/years'] || 3
     end
 
     def clear


### PR DESCRIPTION
## Summary

- develop の 056f1a9 を master にバックポート
- `Entry.create` で DB 挿入後、`keep_years` より古いエントリの投稿をスキップ
- `keep_years` のデフォルトは3年（ソース定義 YAML の `/keep/years` で上書き可能）

## Test plan

- [x] `bundle exec rake test` 全パス
- [x] `bundle exec rubocop` クリーン

Closes #1427

🤖 Generated with [Claude Code](https://claude.com/claude-code)