### PR TITLE
fix: scheduler_daemon の FD を無条件 reopen して EPIPE を根治 (v4.1.1)

### DIFF
--- a/bin/scheduler_daemon.rb
+++ b/bin/scheduler_daemon.rb
@@ -3,13 +3,9 @@
 $LOAD_PATH.unshift(File.join(File.expand_path('..', __dir__), 'app/lib'))
 ENV['RAKE'] = nil
 
+$stdin.reopen(File::NULL, 'r') unless $stdin.tty?
 [$stdout, $stderr].each do |io|
-  next if io.tty?
-  begin
-    io.flush
-  rescue Errno::EPIPE, IOError
-    io.reopen(File::NULL, 'w')
-  end
+  io.reopen(File::NULL, 'w') unless io.tty?
 end
 
 require 'tomato_shrieker'

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -41,7 +41,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/tomato-shrieker
-  version: 4.1.0
+  version: 4.1.1
 nostr:
   relays:
     - wss://relay.damus.io


### PR DESCRIPTION
## Summary

v4.1.0 の EPIPE hotfix が機能しておらず、CommandSource 系 7 本が 4.0 以降恒常的に失敗し続けていた問題の本修正。本番 seas の procstat で FD 0/1/2 が pipe のまま残存、`source_run_log` も直近まで `Errno::EPIPE: Broken pipe @ rb_io_flush_raw - <STDOUT>` が連続している事を確認。

## 原因

`bin/scheduler_daemon.rb` の v4.1.0 hotfix は `io.flush` が EPIPE を raise した場合のみ `File::NULL` に reopen する設計だった。しかし空バッファの `flush` は write を発行せず、無リーダー pipe でも例外にならないため reopen 条件に到達しなかった。

その後 daemon プロセス内で `puts` / logger 等により $stdout バッファに内容が溜まると、`Open3.capture3` 経由の fork-time flush で EPIPE が露呈する。bin/shrieker (TTY 接続の foreground 実行) ではこの問題は発生しない。

## 修正

非 tty のときは条件分岐なしで STDIN/STDOUT/STDERR を `File::NULL` に reopen するように変更。

```ruby
$stdin.reopen(File::NULL, 'r') unless $stdin.tty?
[$stdout, $stderr].each do |io|
  io.reopen(File::NULL, 'w') unless io.tty?
end
```

## 影響範囲

- CommandSource 系 7 本 (dqdai-anniv, dqdai-reserve, everybody, letsla, lovelink, precure-reserve, shooby) が復旧見込み
- bin/shrieker (foreground / TTY) は `unless io.tty?` で従来通り影響なし
- scheduler_daemon のログは `Ginseng::Logger` のファイル出力で、STDOUT/STDERR には依存していない

## Test plan

- [x] bundle exec rake test (83 tests / 477 assertions, all pass)
- [x] bundle exec rubocop bin/scheduler_daemon.rb (違反なし)
- [x] 壊れた pipe を掴ませた子プロセスで v4.1.0 方式が再現エラーとなり、本修正では解消することをローカル再現で確認
- [ ] デプロイ後: seas で procstat が FD 0/1/2 の NAME を `/dev/null` で表示すること
- [ ] デプロイ後: CommandSource 7 本の `source_run_log.status = 'success'` を確認