### PR TITLE
4.1.1

### DIFF
--- a/bin/scheduler_daemon.rb
+++ b/bin/scheduler_daemon.rb
@@ -3,13 +3,9 @@
 $LOAD_PATH.unshift(File.join(File.expand_path('..', __dir__), 'app/lib'))
 ENV['RAKE'] = nil
 
+$stdin.reopen(File::NULL, 'r') unless $stdin.tty?
 [$stdout, $stderr].each do |io|
-  next if io.tty?
-  begin
-    io.flush
-  rescue Errno::EPIPE, IOError
-    io.reopen(File::NULL, 'w')
-  end
+  io.reopen(File::NULL, 'w') unless io.tty?
 end
 
 require 'tomato_shrieker'

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -41,7 +41,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/tomato-shrieker
-  version: 4.1.0
+  version: 4.1.1
 nostr:
   relays:
     - wss://relay.damus.io


### PR DESCRIPTION
v4.1.1 リリース。

## Summary

- #1442 scheduler_daemon の STDIN/STDOUT/STDERR を非 tty 時に無条件で /dev/null に reopen

v4.1.0 で CommandSource 系 7 本の EPIPE 失敗を修正したつもりだったが、`io.flush` ベースの条件付き reopen が空バッファで素通りし、実機では依然として全失敗していた。本番 seas の procstat および `source_run_log` で現象を確認、本 PR で無条件 reopen に変更して根治する。

## Test plan

- [x] PR #1442 の CI グリーン
- [x] ローカルで v4.1.0 方式の失敗と本修正の成功を再現
- [ ] デプロイ後: seas の procstat で FD 0/1/2 が `/dev/null` を指すこと
- [ ] デプロイ後: CommandSource 7 本 (dqdai-anniv, dqdai-reserve, everybody, letsla, lovelink, precure-reserve, shooby) の `source_run_log.status = 'success'` を確認