### PR TITLE
fix: タグ処理での SystemStackError でソースが silent fail する問題を修正 (#1447)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,10 +34,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: a9a168441a84aff8b01b19d664c4d6a6d031d20f
+  revision: bfb0dc260c8a74ff4e7bdde559a9167ce3b8d3a9
   branch: main
   specs:
-    ginseng-fediverse (1.8.22)
+    ginseng-fediverse (1.8.24)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git
@@ -357,7 +357,7 @@ CHECKSUMS
   find (0.2.0) sha256=9aabac9dbbea3fdd23781f79a2fd626166e57dab349aaec449400811b40c371b
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   ginseng-core (1.15.24)
-  ginseng-fediverse (1.8.22)
+  ginseng-fediverse (1.8.24)
   ginseng-piefed (0.1.1)
   ginseng-youtube (2.0.1)
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1

--- a/app/lib/tomato_shrieker/model/entry.rb
+++ b/app/lib/tomato_shrieker/model/entry.rb
@@ -29,7 +29,6 @@ module TomatoShrieker
         tags.concat(feed.tags.clone)
         tags.concat(JSON.parse(extra_tags))
         tags.concat(fetch_remote_tags) if feed.remote_tagging?
-        tags.select! {|v| feed.tag_min_length < v.to_s.length}
         @tags = tags.create_tags
       end
       return @tags

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -44,7 +44,8 @@ module TomatoShrieker
           next
         end
         shrieker.exec(params)
-      rescue => e
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        raise if e.is_a?(SignalException) || e.is_a?(SystemExit)
         Sentry.capture_exception(e) if Sentry.initialized?
         logger.error(source: id, shrieker: shrieker.class.to_s, error: e)
         @delivery_errors_mutex&.synchronize {@delivery_errors << e} if collect_delivery_errors
@@ -211,15 +212,10 @@ module TomatoShrieker
       return (self['/dest/tags'] || []).map(&:to_hashtag)
     end
 
-    def tag_min_length
-      return 2
-    end
-
     def create_tags(status)
       container = Ginseng::Fediverse::TagContainer.new
       container.concat(tags.clone)
       container.concat(mulukhiya.search_hashtags(status)) if remote_tagging?
-      container.select! {|v| tag_min_length < v.to_s.length}
       return container.create_tags
     end
 
@@ -341,7 +337,8 @@ module TomatoShrieker
       logger.info(source: id, class: self.class.to_s, action: 'exec start', method.to_sym => spec)
       exec
       finalize_run_log(started_at)
-    rescue => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      raise if e.is_a?(SignalException) || e.is_a?(SystemExit)
       SourceRunLog.record_error(id, started_at:, error: e)
       Sentry.capture_exception(e) if Sentry.initialized?
       logger.error(source: id, error: e)

--- a/test/source.rb
+++ b/test/source.rb
@@ -175,5 +175,24 @@ module TomatoShrieker
         assert_kind_of(String, source_class[:config])
       end
     end
+
+    def test_create_tags
+      source = TextSource.new('source' => {'text' => 'dummy'}, 'dest' => {'tags' => ['precure_fun']})
+      tags = source.create_tags('dummy')
+
+      assert_kind_of(Set, tags)
+      assert_equal(Set['#precure_fun'], tags)
+    end
+
+    def test_create_tags_with_short_tag
+      # 2文字以下のタグも素通しする (短タグフィルタはモロヘイヤ側責務)
+      source = TextSource.new('source' => {'text' => 'dummy'}, 'dest' => {'tags' => ['実況', 'precure_fun']})
+
+      assert_nothing_raised do
+        tags = source.create_tags('dummy')
+
+        assert_equal(Set['#実況', '#precure_fun'], tags)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- TextSource (curesta-nichiasa-livecure, curesta-night-livecure) が v4.0.0 以降一度も発火していなかった件を修正
- 原因: `Ginseng::Fediverse::TagContainer#delete` の Ruby 4.0 下での無限再帰 + `Source#exec_with_run_log` / `Source#shriek` の rescue が SystemStackError を捕まえず source_run_log にも残らないサイレント失敗
- 上流: pooza/ginseng-fediverse#240 (v1.8.24) で再帰を修正
- 本 PR: `Source#create_tags` から短タグフィルタを削除 (モロヘイヤ責務であって tomato-shrieker では不要) + rescue を Exception 拡張で安全網

Fixes #1447

## Test plan

- [x] `bundle exec rake test` 全 85 件パス
- [x] `bundle exec rubocop` クリーン
- [x] `Source#create_tags` の単体テスト 2 件追加 (通常ケース + 短タグを含むケース)
- [ ] 本番デプロイ後、curesta-night-livecure (毎日 19:55 JST) の発火と投稿を source_run_log + モロヘイヤ Webhook 受信ログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)