### PR TITLE
4.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: b2e3d06d7702c6c1e743dd3b4168dda5d74b553e
+  revision: 98a72b02e5c560e7bf9914fe5b13e89bfbff51b6
   branch: main
   specs:
-    ginseng-core (1.15.25)
+    ginseng-core (1.15.26)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -331,4 +331,4 @@ RUBY VERSION
   ruby 4.0.5
 
 BUNDLED WITH
-  4.0.13
+  4.0.14

--- a/app/lib/tomato_shrieker/model/entry.rb
+++ b/app/lib/tomato_shrieker/model/entry.rb
@@ -62,11 +62,12 @@ module TomatoShrieker
       return template
     end
 
-    def shriek
+    def shriek(delivery_errors: nil)
       feed.shriek(
         template: create_template,
         visibility: feed.visibility,
         attachments: enclosures.map {|v| {image_url: v.to_s}}.first(4),
+        delivery_errors:,
       )
       logger.info(source: feed.id, entry: to_h, message: 'post')
     end

--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -35,16 +35,18 @@ module TomatoShrieker
     def healthz_source(source_id)
       source = Source.create(source_id)
       return [404, HEADERS, ["Unknown source: #{source_id}\n"]] unless source
-      tolerance = source.run_tolerance_seconds
-      return [200, HEADERS, ["OK (not monitored)\n"]] unless tolerance
+      return [200, HEADERS, ["OK (not monitored)\n"]] unless source.monitored?
       latest = SourceRunLog.latest_for(source_id)
       return [503, HEADERS, ["No run recorded yet\n"]] unless latest
-      stale = Time.now - latest.executed_at > tolerance
+      next_run = source.next_run_at(latest.executed_at)
+      grace = source.monitor_grace_seconds
+      stale = Time.now > next_run + grace
       errored = latest.status == SourceRunLog::STATUS_ERROR
       return [200, HEADERS, ["OK\n"]] unless stale || errored
       body = "status: #{latest.status}\n"
       body << "executed_at: #{latest.executed_at.iso8601}\n"
-      body << "tolerance_seconds: #{tolerance}\n"
+      body << "next_run_at: #{next_run.iso8601}\n"
+      body << "grace_seconds: #{grace}\n"
       body << "stale: #{stale}\n"
       body << "error: #{latest.error_message}\n" if errored
       return [503, HEADERS, [body]]
@@ -64,12 +66,14 @@ module TomatoShrieker
 
     def source_status(source)
       latest = SourceRunLog.latest_for(source.id)
+      next_run = (source.next_run_at(latest.executed_at) if source.monitored? && latest)
       {
         id: source.id,
         class: source.class.to_s,
         schedule: source.schedule_spec,
-        tolerance_seconds: source.run_tolerance_seconds,
+        grace_seconds: source.monitor_grace_seconds,
         last_run_at: latest&.executed_at&.iso8601,
+        next_run_at: next_run&.iso8601,
         last_status: latest&.status,
         last_error: latest&.error_message,
         last_duration_ms: latest&.duration_ms,

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -265,17 +265,21 @@ module TomatoShrieker
       return {type: 'every', value: period}
     end
 
-    def run_tolerance_seconds
+    def monitored?
+      return post_at.nil?
+    end
+
+    def next_run_at(after)
+      return nil if post_at
+      return Rufus::Scheduler.parse(cron).next_time(after).to_t if cron
+      return after + Rufus::Scheduler.parse(period)
+    end
+
+    def monitor_grace_seconds
       return nil if post_at
       override = self['/monitor/tolerance']
       return Rufus::Scheduler.parse(override).to_i if override.is_a?(String)
       return override.to_i if override.is_a?(Numeric)
-      return (Rufus::Scheduler.parse(period) * 2).to_i if period
-      return cron_interval_seconds * 2 if cron
-      return default_tolerance_seconds
-    end
-
-    def default_tolerance_seconds
       return Config.instance['/monitor/default_tolerance_seconds']
     end
 
@@ -307,21 +311,6 @@ module TomatoShrieker
     end
 
     private
-
-    def cron_interval_seconds
-      @cron_interval_seconds ||= calculate_cron_interval_seconds
-    end
-
-    def calculate_cron_interval_seconds
-      parsed = Rufus::Scheduler.parse(cron)
-      times = [parsed.next_time]
-      deadline = times.first + (2 * 366 * 86_400)
-      10_000.times do
-        times << parsed.next_time(times.last)
-        break if times.last >= deadline
-      end
-      return times.each_cons(2).map {|a, b| (b - a).to_i}.max
-    end
 
     def schedule(method, spec)
       job = Scheduler.instance.scheduler.send(method.to_sym, spec, {tag: id, overlap: false}) do

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -35,7 +35,7 @@ module TomatoShrieker
       return schedule(:every, every)
     end
 
-    def shriek(template: nil, visibility: nil, attachments: nil, collect_delivery_errors: true)
+    def shriek(template: nil, visibility: nil, attachments: nil, delivery_errors: @delivery_errors)
       params = {template:, visibility:, attachments:}.compact
       shriekers do |shrieker|
         if Environment.test?
@@ -49,7 +49,7 @@ module TomatoShrieker
         klass = shrieker.class.to_s
         Sentry.capture_exception(e, tags: {source: id, shrieker: klass}) if Sentry.initialized?
         logger.error(source: id, shrieker: klass, error: e)
-        @delivery_errors_mutex&.synchronize {@delivery_errors << e} if collect_delivery_errors
+        delivery_errors << e if delivery_errors
       end
     end
 
@@ -322,8 +322,7 @@ module TomatoShrieker
 
     def exec_with_run_log(method, spec)
       started_at = Time.now
-      @delivery_errors = []
-      @delivery_errors_mutex = Mutex.new
+      @delivery_errors = Thread::Queue.new
       logger.info(source: id, class: self.class.to_s, action: 'exec start', method.to_sym => spec)
       exec
       finalize_run_log(started_at)
@@ -335,11 +334,12 @@ module TomatoShrieker
     end
 
     def finalize_run_log(started_at)
-      if @delivery_errors.any?
-        SourceRunLog.record_error(id, started_at:, error: @delivery_errors.first)
+      count = @delivery_errors.size
+      if count.positive?
+        SourceRunLog.record_error(id, started_at:, error: @delivery_errors.pop)
         logger.error(
           source: id, class: self.class.to_s,
-          action: 'exec end (delivery errors)', count: @delivery_errors.size
+          action: 'exec end (delivery errors)', count:
         )
       else
         SourceRunLog.record_success(id, started_at:)

--- a/app/lib/tomato_shrieker/source/feed_source.rb
+++ b/app/lib/tomato_shrieker/source/feed_source.rb
@@ -10,9 +10,9 @@ module TomatoShrieker
 
     def exec
       if touched?
-        fetch(&:shriek)
+        fetch {|entry| entry.shriek(delivery_errors: @delivery_errors)}
       elsif entry = fetch.to_a.last
-        entry.shriek
+        entry.shriek(delivery_errors: @delivery_errors)
       end
     end
 

--- a/app/lib/tomato_shrieker/source/icalendar_source.rb
+++ b/app/lib/tomato_shrieker/source/icalendar_source.rb
@@ -40,7 +40,7 @@ module TomatoShrieker
         template = create_template
         template[:entry] = entry
         template[:remind] = true
-        shriek(template:, visibility:, collect_delivery_errors: false)
+        shriek(template:, visibility:, delivery_errors: nil)
       end
     rescue => e
       logger.error(source: id, error: e)

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -41,7 +41,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/tomato-shrieker
-  version: 4.1.3
+  version: 4.2.0
 nostr:
   relays:
     - wss://relay.damus.io

--- a/test/source.rb
+++ b/test/source.rb
@@ -157,14 +157,34 @@ module TomatoShrieker
       end
     end
 
-    def test_run_tolerance_seconds
+    def test_monitored?
       Source.all.each do |source|
-        tolerance = source.run_tolerance_seconds
+        assert_boolean(source.monitored?)
+        assert_equal(source.post_at.nil?, source.monitored?)
+      end
+    end
+
+    def test_next_run_at
+      now = Time.now
+      Source.all.each do |source|
+        next_run = source.next_run_at(now)
         if source.post_at
-          assert_nil(tolerance)
+          assert_nil(next_run)
         else
-          assert_kind_of(Integer, tolerance)
-          assert_operator(tolerance, :>, 0)
+          assert_kind_of(Time, next_run)
+          assert_operator(next_run, :>, now)
+        end
+      end
+    end
+
+    def test_monitor_grace_seconds
+      Source.all.each do |source|
+        grace = source.monitor_grace_seconds
+        if source.post_at
+          assert_nil(grace)
+        else
+          assert_kind_of(Integer, grace)
+          assert_operator(grace, :>, 0)
         end
       end
     end

--- a/test/source.rb
+++ b/test/source.rb
@@ -189,6 +189,32 @@ module TomatoShrieker
       end
     end
 
+    # #1456: 配信エラーは渡された collector へ集約され、別インスタンス経由でも記録される。
+    def test_shriek_collects_delivery_errors
+      saved = ENV.fetch('TEST', nil)
+      ENV.delete('TEST') # Environment.test? を false にし shrieker を実際に走らせる
+      shrieker = Object.new
+      def shrieker.exec(_params)
+        raise('simulated delivery failure')
+      end
+      source = Source.new({'id' => 'test-delivery-collect'})
+      source.define_singleton_method(:shriekers) do |&block|
+        next enum_for(:shriekers) unless block
+        block.call(shrieker)
+      end
+      queue = Thread::Queue.new
+      source.shriek(template: nil, visibility: nil, delivery_errors: queue)
+
+      assert_equal(1, queue.size)
+      assert_kind_of(RuntimeError, queue.pop)
+      assert_nothing_raised do
+        source.shriek(template: nil, visibility: nil, delivery_errors: nil)
+      end
+      assert_equal(0, queue.size)
+    ensure
+      ENV['TEST'] = saved
+    end
+
     def test_classes
       Source.classes.each do |source_class|
         assert_kind_of(Class, source_class[:class])


### PR DESCRIPTION
## 4.2.0

監視まわりの再構成を中心としたマイナーリリース。

### リファクタリング
- **refactor**: 監視 tolerance の計算を次回発火時刻ベースに変更し、cron 全ギャップ計算(10000ループ)を廃止 (#1441) — `monitored?` / `next_run_at` / `monitor_grace_seconds` を新設。`/healthz` と `status.json` に `next_run_at` を追加。

### バグ修正
- **fix**: FeedSource の配信失敗が `run_log` に記録されず `/healthz/source` が常に 200 を返していた問題を修正 (#1456) — `@delivery_errors` がインスタンス不一致で機能していなかったのを、`Thread::Queue` collector を呼び出し連鎖で引き回し、別インスタンス・別スレッドからも集約できるように変更。

### 依存更新
- bundle update

---
※ #1456 はコア修正のみ。配信試行ベースの error_streak / no-op を健全扱いする件は #1457 (4.3.0) に切り出し済み。